### PR TITLE
Add scipy and custom text similarity scoring functions and softmax option

### DIFF
--- a/src/lazyslide/tools/_text_annotate.py
+++ b/src/lazyslide/tools/_text_annotate.py
@@ -74,6 +74,8 @@ def text_image_similarity(
     tile_key: str = Key.tiles,
     feature_key: str = None,
     key_added: str = None,
+    softmax=False,
+    scoring_func: callable = None,
 ):
     """
     Compute the similarity between text and image.
@@ -81,8 +83,10 @@ def text_image_similarity(
     .. note::
         Prerequisites:
 
-        - The image features should be extracted using :func:`zs.tl.feature_extraction <lazyslide.tl.feature_extraction>`.
-        - The text embeddings should be computed using :func:`zs.tl.text_embedding <lazyslide.tl.text_embedding>`.
+        - The image features should be extracted using
+          :func:`zs.tl.feature_extraction <lazyslide.tl.feature_extraction>`.
+        - The text embeddings should be computed using
+          :func:`zs.tl.text_embedding <lazyslide.tl.text_embedding>`.
 
     Parameters
     ----------
@@ -97,14 +101,33 @@ def text_image_similarity(
     feature_key : str
         The feature key.
     key_added : str
-        The key to store the similarity scores. If None, defaults to '{feature_key}_text_similarity'.
+        The key to store the similarity scores. If None, defaults to
+        '{feature_key}_text_similarity'.
+    softmax : bool, default: False
+        Whether to apply softmax to the similarity scores.
+    distance_metric : str or callable, optional
+        The distance metric from scipy.spatial.distance to use instead of
+        dot product. Can be a string metric name or a callable function.
+        If provided, distances will be computed and converted to similarities
+        (1 - distance). Common string options include 'cosine', 'euclidean',
+        'manhattan', 'chebyshev', etc. If None, uses dot product similarity.
+        Cannot be used together with scoring_func.
+    scoring_func : callable, optional
+        A custom scoring/similarity function that takes two matrices and
+        returns a similarity score matrix (higher = more similar). Should
+        have same signature as np.dot: func(X, Y) where X is (n_texts,
+        feature_dim) and Y is (feature_dim, n_features), returning
+        (n_texts, n_features). If provided, this takes precedence over
+        distance_metric and dot product. Cannot be used together with
+        distance_metric.
 
     Returns
     -------
     None
 
     .. note::
-        The similarity scores will be saved as an  to :bdg-danger:`tables` slot of the spatial data object.
+        The similarity scores will be saved as an to :bdg-danger:`tables`
+        slot of the spatial data object.
 
     Examples
     --------
@@ -112,14 +135,18 @@ def text_image_similarity(
     .. code-block:: python
 
         >>> import lazyslide as zs
-        >>> wsi = zs.datasets.sample()
-        >>> zs.pp.find_tissues(wsi)
-        >>> zs.pp.tile_tissues(wsi, 256, mpp=0.5, key_added="text_tiles")
-        >>> zs.tl.feature_extraction(wsi, "plip", tile_key="text_tiles")
-        >>> terms = ["mucosa", "submucosa", "musclaris", "lymphocyte"]
-        >>> embeddings = zs.tl.text_embedding(terms, model="plip")
-        >>> zs.tl.text_image_similarity(wsi, embeddings, model="plip", tile_key="text_tiles")
-
+        >>> # Using dot product similarity (default)
+        >>> zs.tl.text_image_similarity(wsi, embeddings, model="plip",
+        ...                             tile_key="text_tiles",
+        ...                             softmax=True)
+        >>> # Using scipy distance functions
+        >>> zs.tl.text_image_similarity(wsi, embeddings, model="plip",
+        ...                             tile_key="text_tiles",
+        ...                             distance_metric="euclidean")
+        >>> # Using custom scoring function
+        >>> zs.tl.text_image_similarity(wsi, embeddings, model="plip",
+        ...                             tile_key="text_tiles",
+        ...                             scoring_func=custom_scoring_func)
     """
 
     if feature_key is None:
@@ -128,7 +155,31 @@ def text_image_similarity(
     key_added = f"{feature_key}_text_similarity" or key_added
 
     feature_X = wsi.tables[feature_key].X
-    similarity_score = np.dot(text_embeddings.values, feature_X.T).T
+
+    if scoring_func is not None:
+        if callable(scoring_func):
+            try:
+                similarity_score = scoring_func(text_embeddings.values, feature_X.T).T
+            except Exception as e:
+                raise ValueError(
+                    f"Error in custom scoring_func: {str(e)}. "
+                    f"Function should accept (n_texts, feature_dim) and "
+                    f"(feature_dim, n_features) matrices and return "
+                    f"(n_texts, n_features) similarity matrix."
+                ) from e
+        elif isinstance(scoring_func, str):
+            from scipy.spatial.distance import cdist
+
+            similarity_score = cdist(
+                text_embeddings.values, feature_X, metric=scoring_func
+            ).T
+    else:
+        similarity_score = np.dot(text_embeddings.values, feature_X.T).T
+
+    if softmax:
+        from scipy.special import softmax
+
+        similarity_score = softmax(similarity_score, axis=1)
 
     add_features(
         wsi,


### PR DESCRIPTION


## ✨ Context
closes #103 

## Type of changes

- [ x] ✨ New Feature (changes that introduce new functionality)

## 🛠 What does this PR implement

- Add keyword parameters for `tl.text_image_similarity`
  - `scoring_func`: User can pass either scipy distance function as string, or a custom function
  - `softmax`: Toggle whether to apply softmax on the similarity scores
