### PR TITLE
Add Docker support for CLI and Jupyter access (#30)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,93 @@
+# Git
+# .git  # Commented out - needed for version detection
+.gitignore
+
+# Python
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+env
+pip-log.txt
+pip-delete-this-directory.txt
+.tox
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.log
+# .git  # Commented out - needed for version detection
+.mypy_cache
+.pytest_cache
+.hypothesis
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Documentation
+docs/
+*.md
+!README.md
+
+# Assets and media
+assets/
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.svg
+*.ai
+
+# Build artifacts
+build/
+dist/
+*.egg-info/
+.eggs/
+
+# Jupyter
+.ipynb_checkpoints
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# CI/CD
+.github/
+.gitlab-ci.yml
+.travis.yml
+.circleci/
+
+# Docker
+# Dockerfile*  # Commented out - needed for build
+docker-compose*.yml
+# .dockerignore  # Commented out - needed for build
+
+# Other
+*.tmp
+*.temp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,105 @@
+# Multi-stage Dockerfile for LazySlide
+# Build: docker build -t lazyslide .
+# CLI usage: docker run -it --rm lazyslide python
+# Jupyter usage: docker run -it --rm -p 8888:8888 lazyslide jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --allow-root
+# IPython usage: docker run -it --rm lazyslide ipython
+
+# Use a smaller base image for runtime
+FROM python:3.11-slim AS base
+
+# Set environment variables for faster builds and better performance
+ENV PYTHONUNBUFFERED=1
+ENV CFLAGS="-O2 -march=native"
+ENV CXXFLAGS="-O2 -march=native"
+ENV MAX_JOBS=4
+ENV PIP_NO_CACHE_DIR=1
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PYTORCH_ENABLE_MPS_FALLBACK=1
+ENV HF_HOME=/tmp/hf_home
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies in a single layer
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    gcc \
+    g++ \
+    git \
+    wget \
+    curl \
+    libgl1-mesa-dri \
+    libglib2.0-0 \
+    libsm6 \
+    libxext6 \
+    libxrender1 \
+    libgomp1 \
+    libgcc-s1 \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+# Install uv for faster Python package management
+RUN pip install --no-cache-dir uv
+
+# Dependencies stage - install Python packages
+FROM base AS deps
+WORKDIR /app
+
+# Copy only dependency files first for better caching
+COPY pyproject.toml uv.lock ./
+
+# Install dependencies without the project
+RUN uv sync --group tests --group dev --extra all --extra models --no-install-project
+
+# Install Jupyter Lab and IPython for interactive use
+RUN uv pip install jupyterlab ipython
+
+# Build stage - install the project
+FROM deps AS builder
+WORKDIR /app
+
+# Copy git directory for version detection
+COPY .git/ ./.git/
+
+# Copy source code, tests, and README
+COPY src/ ./src/
+COPY tests/ ./tests/
+COPY README.md ./
+
+# Install the project in development mode
+RUN uv run pip install -e .
+
+# Runtime stage - minimal image
+FROM python:3.11-slim AS runtime
+
+# Install only runtime system dependencies
+RUN apt-get update && apt-get install -y \
+    libgl1-mesa-dri \
+    libglib2.0-0 \
+    libsm6 \
+    libxext6 \
+    libxrender1 \
+    libgomp1 \
+    libgcc-s1 \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1
+ENV PYTORCH_ENABLE_MPS_FALLBACK=1
+ENV HF_HOME=/tmp/hf_home
+ENV PATH="/app/.venv/bin:$PATH"
+
+WORKDIR /app
+
+# Copy the virtual environment from builder
+COPY --from=builder /app/.venv /app/.venv
+
+# Copy only necessary files
+COPY --from=builder /app/src/ ./src/
+COPY --from=builder /app/tests/ ./tests/
+COPY pyproject.toml ./
+
+# Verify installation
+RUN python -c "import lazyslide as zs; print(f'LazySlide version: {zs.__version__}')"
+
+# Default command - provide a shell for manual execution
+CMD ["/bin/bash"]


### PR DESCRIPTION
# Add Docker support for CLI and Jupyter access

## Context

Implements Docker containerization for LazySlide to enable easy deployment and usage through both CLI and interactive Jupyter environments as requested in issue #30.

## Rationale behind the change

- Provides consistent, reproducible environment across different systems
- Enables easy distribution and deployment without complex dependency management
- Supports both CLI and interactive Jupyter usage patterns
- Uses multi-stage build for optimal image size and build caching

## Type of changes

- [x] New Feature (changes that introduce new functionality)
- [x] Improvements (Minor refactoring, code changes or optimizations)

## What does this PR implement

- Multi-stage Dockerfile with optimized layer caching
- Jupyter Lab and IPython support for interactive usage
- CLI access through Python interpreter
- .dockerignore for efficient build context
- Optimized dependencies installation in separate stage

**Usage examples:**
```bash
# CLI usage
docker run -it --rm lazyslide python

# IPython usage  
docker run -it --rm lazyslide ipython

# Jupyter Lab usage
docker run -it --rm -p 8888:8888 lazyslide jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --allow-root
```

## Missing

None - all requirements from issue #30 are implemented.

## How should this be tested?

```bash
# Build the image
docker build -t lazyslide .

# Test CLI access
docker run --rm lazyslide python -c "import lazyslide as zs; print(zs.__version__)"

# Test IPython access
docker run --rm lazyslide ipython -c "import lazyslide as zs; print('IPython works')"

# Test Jupyter availability
docker run --rm lazyslide jupyter --version
```