### PR TITLE
[Fix] Make Histoplus model work with all valid tile specifications

### DIFF
--- a/src/lazyslide/segmentation/_cell.py
+++ b/src/lazyslide/segmentation/_cell.py
@@ -183,7 +183,7 @@ def cell_types(
         if model is None:
             raise ValueError(f"Unknown model: {model}")
 
-        model_instance = model(magnification=magnification)
+        model_instance = model(**model_kwargs)
 
     CLASS_MAPPING = model.get_classes()
     if model_instance.check_input_tile(tile_spec):


### PR DESCRIPTION
## ✨ Context
Related to #177. Histoplus cell segmentation fails for valid tile specifications 

## 🧠 Rationale behind the change
Fix model initialization where only the magnification is passed instead of all specifications, including tile_height. This leads to an error when running the model with any other tile size than 840 px (default) and likely leads to unexpected behavior in other segmentation runs as well. 

## Type of changes
- [x] 🐛 Bugfix (changes that fix a problem with the current behavior)

