### PR TITLE
Add FLOPS estimation functionality to ModelBase

### DIFF
--- a/src/lazyslide/models/base.py
+++ b/src/lazyslide/models/base.py
@@ -50,10 +50,12 @@ class ModelBase(ABC):
                 return None
         return sum(p.numel() for p in model.parameters())
 
-    def _resolve_method(self, model: torch.nn.Module, method: str) -> tuple[Any, torch.nn.Module] | None:
+    def _resolve_method(
+        self, model: torch.nn.Module, method: str
+    ) -> tuple[Any, torch.nn.Module] | None:
         """Resolve method path and return (callable, target_model) for FLOPS counting."""
-        if '.' in method:
-            parts = method.split('.')
+        if "." in method:
+            parts = method.split(".")
             obj, target = model, model
             for part in parts[:-1]:
                 obj = getattr(obj, part, None)
@@ -63,11 +65,13 @@ class ModelBase(ABC):
                     target = obj
             method_obj = getattr(obj, parts[-1], None)
             return (method_obj, target) if method_obj else None
-        
+
         method_obj = getattr(model, method, None) or getattr(self, method, None)
         return (method_obj, model) if method_obj else None
 
-    def estimate_flops(self, method: str = "forward", *args: Any, **kwargs: Any) -> int | None:
+    def estimate_flops(
+        self, *args: Any, method: str = "forward", **kwargs: Any
+    ) -> int | None:
         """Count the number of flops in a model."""
         model = self.model
         if not isinstance(model, torch.nn.Module):
@@ -77,11 +81,11 @@ class ModelBase(ABC):
                 return None
         if isinstance(model, torch.nn.DataParallel):
             model = model.module
-        
+
         result = self._resolve_method(model, method)
         if result is None:
             return None
-        
+
         method_obj, target = result
         is_training = model.training
         model.eval()

--- a/tests/models/test_models_general.py
+++ b/tests/models/test_models_general.py
@@ -38,7 +38,11 @@ MODEL_INPUT_ARGS = {
     "histoplus": {"args": [torch.randn(1, 3, 840, 840)]},
     "instanseg": {"args": [torch.randn(1, 3, 224, 224)]},
     "madeleine": {"args": [torch.randn(1, 100, 512)]},
-    "medsiglip": {"args": [], "kwargs": {"pixel_values": torch.randn(1, 3, 448, 448)}, "method": "get_image_features"},
+    "medsiglip": {
+        "args": [],
+        "kwargs": {"pixel_values": torch.randn(1, 3, 448, 448)},
+        "method": "get_image_features",
+    },
     "midnight": {"args": [torch.randn(1, 3, 224, 224)]},
     "musk": {"args": [torch.randn(1, 3, 384, 384)]},
     "nulite": {"args": [torch.randn(1, 3, 224, 224)]},
@@ -48,8 +52,15 @@ MODEL_INPUT_ARGS = {
     "pathprofilerqc": {"args": [torch.randn(1, 3, 224, 224)]},
     "phikon": {"args": [torch.randn(1, 3, 224, 224)]},
     "phikonv2": {"args": [torch.randn(1, 3, 224, 224)]},
-    "plip": {"args": [], "kwargs": {"pixel_values": torch.randn(1, 3, 224, 224)}, "method": "get_image_features"},
-    "prism": {"args": [torch.randn(1, 100, 768)], "method": "model.slide_representations"},
+    "plip": {
+        "args": [],
+        "kwargs": {"pixel_values": torch.randn(1, 3, 224, 224)},
+        "method": "get_image_features",
+    },
+    "prism": {
+        "args": [torch.randn(1, 100, 768)],
+        "method": "model.slide_representations",
+    },
     "rosie": {"args": [torch.randn(1, 3, 224, 224)]},
     "sam": {"args": [torch.randn(1, 3, 1024, 1024)]},
     "saturation": {"args": [torch.randn(1, 3, 224, 224)]},
@@ -101,7 +112,7 @@ def test_model_init(model_name):
             input_config = MODEL_INPUT_ARGS[model_name]
             method = input_config.get("method", "forward")
             kwargs = input_config.get("kwargs", {})
-            _ = model.estimate_flops(method, *input_config["args"], **kwargs)
+            _ = model.estimate_flops(*input_config["args"], method=method, **kwargs)
 
     # Test the to device function
     model_on_device = model.to("cpu")


### PR DESCRIPTION
# Add FLOPS estimation functionality

## ✨ Context

This PR adds FLOPS (Floating Point Operations) estimation capability to the ModelBase class, addressing issue #180 for model complexity/resource utilization comparison.

## 🧠 Rationale behind the change

FLOPS estimation is needed to compare model resource requirements beyond just parameter count, as parameter count doesn't linearly correlate with computational complexity.

## Type of changes

- [x] ✨ New Feature (changes that introduce new functionality)
- [x] ✅ Tests (Unit tests, integration tests, end-to-end tests)

## 🛠 What does this PR implement

- Add `estimate_flops()` method to `ModelBase` using `torch.utils.flop_counter.FlopCounterMode`
- Add `_resolve_method()` helper to resolve method paths for FLOPS counting (supports nested methods like `conch.forward`)
- Add `MODEL_INPUT_ARGS` dictionary with test inputs for all models in the registry
- Add FLOPS estimation tests in `test_models_general.py` that verify FLOPS can be computed for each model

## 🙈 Missing

- Documentation page with comparison table (parameter count, FLOPS, inference time) - to be added in follow-up PR
- Inference time measurement - to be added in follow-up PR

## 🧪 How should this be tested?

- `uv run pytest tests/models/test_models_general.py::test_model_init` - verifies FLOPS estimation works for all models

Addresses #180