### PR TITLE
Fix zoom image was shown even when not added and potential bugs in `DataSource`

### DIFF
--- a/src/lazyslide/plotting/_wsi_viewer.py
+++ b/src/lazyslide/plotting/_wsi_viewer.py
@@ -770,6 +770,7 @@ class DatashaderFilledPolygonRenderPlan(RenderPlan):
                 stacklevel=find_stack_level(),
             )
             return
+        import datashader as ds
         from datashader import transfer_functions as tf
 
         # Canvas dimensions and extent based on current image viewport
@@ -1277,6 +1278,7 @@ class WSIViewer:
                     "Falling back to matplotlib for the base view.",
                     stacklevel=find_stack_level(),
                 )
+            import datashader as ds
 
         if use_datashader:
             warnings.warn(


### PR DESCRIPTION
## ✨ Context

Closes #189 Closes #190

Fixed two bugs related to plotting multiple polygons added to a WSI viewer:
1. Even if the image was not added to the viewer it was shown in the zoom anyway.
2. If multiple polygon render plans were added to the wsi viewer their attributes got mixed up since the base class did not initialize these attributes properly and therefore shared them between instances.

## Type of changes

- [x] 🐛 Bugfix (changes that fix a problem with the current behavior)

## 🛠 What does this PR implement

1. added a single if statement to catch whether to show the image in the zoom class PolygonDataSource
2. added __init__ to the base class DataSource to avoid sharing of the class attributes between instances.

