### PR TITLE
Update API reference link in main docs index

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -73,7 +73,7 @@ Whether you're a novice in digital pathology or an expert computational biologis
       Available models in LazySlide
 
    .. grid-item-card:: API Reference
-      :link: tutorials/index
+      :link: api/index
       :link-type: doc
 
       API reference in LazySlide


### PR DESCRIPTION
Previous main link in docs pointed twice to tutorials and had no API entry.

Would be good to fix asap. 