### PR TITLE
Fixed minor issue with zero_shot_classifier call within titan score() function

### DIFF
--- a/src/lazyslide/models/multimodal/titan.py
+++ b/src/lazyslide/models/multimodal/titan.py
@@ -133,6 +133,8 @@ class Titan(
         if template is None:
             template = self.TEMPLATES
 
-        classifier = self.model.zero_shot_classifier(prompts, template)
+        classifier = self.model.zero_shot_classifier(
+            prompts, template, device=slide_embeddings.device
+        )
         scores = self.model.zero_shot(slide_embeddings, classifier)
         return scores


### PR DESCRIPTION
# Fixed minor issue with zero_shot_classifier call within titan score() function

## ✨ Context

While testing some of the zero_shot capabilities I noticed that the current call to zero_shot_classifier in line 136 of titan.py (models/multimodal/titan.py) ignores the compute device flag and defaults to cpu operation. This is not an issue if the previous operations have been performed on CPU but fails if they have been computed on a different device (e.g. a GPU).

Simply passing slide_embeddings.device to self.model.zero_shot_classifier() fixes the issue.

It's important to note that the current relatively lax environment setup for lazyslide may result in the dependency solver (tested with both mamba and uv under pixi) installing an environment with subtle version mismatches that also raise errors in zero_shot_score() (tools/_zero_shot.py) among others. There I had to squeeze the probability vector from model.score() in line 135 before appending to the all_probs variable. I don't think this will be an issue with an environment generated from the uv lock file but it may be worth investigating (or alternatively heavily pointing users towards the uv installation method. 

## Type of changes

- [x] 🐛 Bugfix (changes that fix a problem with the current behavior)

## 🛠 What does this PR implement

Bug fix detailed above

## 🙈 Missing

Look into the environment/dependency constraints and potentially investigate the format of the vectors returned by mode.score() in line 135 of tools/_zero_shot.py 