### PR TITLE
CI: Allow external contributor PRs to run without secrets

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,24 +27,10 @@ jobs:
         python-version: ['3.11', '3.12', '3.13']
 
     runs-on: ${{ matrix.os }}
+    env:
+      # Skip dataset-dependent tests on fork PRs (no HF secrets available).
+      LAZYSLIDE_SKIP_DATASET_TESTS: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'rendeirolab/LazySlide' && '1' || '' }}
     steps:
-      # The following step is to ensure secrets can be accessed by forked PRs
-      # Ref: https://michaelheap.com/access-secrets-from-forks/
-      - name: Get User Permission
-        id: checkAccess
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check User Permission
-        if: steps.checkAccess.outputs.require-result == 'false'
-        run: |
-          echo "${{ github.triggering_actor }} does not have permissions on this repo."
-          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
-          echo "Job originally triggered by ${{ github.actor }}"
-          exit 1
       - uses: actions/checkout@v4
         with:
           ref: ${{  github.event.pull_request.head.sha }} # This is dangerous without human review
@@ -57,12 +43,14 @@ jobs:
       - name: Install project
         run: uv sync --dev
       - name: Login to Hugging Face
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'rendeirolab/LazySlide'
         run: |
           uv run hf auth login --token ${{ secrets.HF_TOKEN }}
       - name: Tests
         run: |
           uv run pytest tests -n auto -m "not large_runner" --cov=src/lazyslide --cov-report=xml --cov-report=html
       - name: Upload coverage reports to Codecov
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'rendeirolab/LazySlide'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,10 @@
+import os
+
 import pytest
 import torch
+
+# When set (e.g. on fork PRs without HF secrets), skip dataset download and fixtures.
+SKIP_DATASET_TESTS = os.environ.get("LAZYSLIDE_SKIP_DATASET_TESTS") == "1"
 
 
 class MockNet(torch.nn.Module):
@@ -18,11 +23,14 @@ def cache_test_datasets():
 
 
 def pytest_sessionstart(session):
-    cache_test_datasets()
+    if not SKIP_DATASET_TESTS:
+        cache_test_datasets()
 
 
 @pytest.fixture(scope="session")
 def wsi():
+    if SKIP_DATASET_TESTS:
+        pytest.skip("Dataset tests skipped (no HF token, e.g. fork PR)")
     import lazyslide as zs
 
     return zs.datasets.gtex_artery()
@@ -30,6 +38,8 @@ def wsi():
 
 @pytest.fixture(scope="class")
 def wsi_small():
+    if SKIP_DATASET_TESTS:
+        pytest.skip("Dataset tests skipped (no HF token, e.g. fork PR)")
     import lazyslide as zs
 
     return zs.datasets.sample()
@@ -57,6 +67,8 @@ def torch_jit_file(tmp_path_session):
 @pytest.fixture(scope="session")
 def wsi_with_annotations():
     """Fixture that provides a WSI with annotations for testing."""
+    if SKIP_DATASET_TESTS:
+        pytest.skip("Dataset tests skipped (no HF token, e.g. fork PR)")
     import geopandas as gpd
     from shapely.geometry import Polygon
 


### PR DESCRIPTION
# CI: Allow external contributor PRs to run without secrets

## ✨ Context

External PRs were failing CI (no secrets). We let fork PRs run tests and skip HF/Codecov; dataset-dependent tests are skipped so they don’t fail without HF token.

## 🧠 Rationale behind the change

Secrets only for same-repo PRs; fork PRs get skips instead of failures for dataset-dependent tests.

## Type of changes

- [x] 👷 🔧 CI or Configuration Files

## 🛠 What does this PR implement

- **build.yaml**: No permission-check fail; HF login and Codecov only for same-repo PRs; `LAZYSLIDE_SKIP_DATASET_TESTS` on fork PRs.
- **conftest.py**: Skip dataset download and wsi fixtures when that env is set.

## 🧪 How should this be tested?

- Fork PR: CI runs, dataset tests skipped. Same-repo PR or push: full CI. `LAZYSLIDE_SKIP_DATASET_TESTS=1 uv run pytest tests -m "not large_runner"` → skips dataset tests.
