### PR TITLE
artifacts segmentation for whole wsi, handling slides with x,y origin != 0

### DIFF
--- a/src/lazyslide/segmentation/_seg_runner.py
+++ b/src/lazyslide/segmentation/_seg_runner.py
@@ -289,10 +289,11 @@ class SemanticSegmentationRunner(Runner):
 
         if not self.has_tissue:
             wsi_bounds = wsi.properties.bounds
+            bx, by, bw, bh = wsi_bounds
             tissues = gpd.GeoDataFrame(
                 {
                     "tissue_id": [0],
-                    "geometry": [box(0, 0, wsi_bounds[2], wsi_bounds[3])],
+                    "geometry": [box(bx, by, bx + bw, by + bh)],
                 }
             )
         else:
@@ -398,6 +399,9 @@ class SemanticSegmentationRunner(Runner):
                                     )
                                 pos_x = int((xs[i] - minx) / self.downsample)
                                 pos_y = int((ys[i] - miny) / self.downsample)
+                                # skip tiles that are outside the tissue bounds
+                                if pos_x >= width or pos_y >= height:
+                                    continue
                                 slice_y = slice(
                                     pos_y,
                                     np.clip(

--- a/src/lazyslide/segmentation/_seg_runner.py
+++ b/src/lazyslide/segmentation/_seg_runner.py
@@ -399,9 +399,6 @@ class SemanticSegmentationRunner(Runner):
                                     )
                                 pos_x = int((xs[i] - minx) / self.downsample)
                                 pos_y = int((ys[i] - miny) / self.downsample)
-                                # skip tiles that are outside the tissue bounds
-                                if pos_x >= width or pos_y >= height:
-                                    continue
                                 slice_y = slice(
                                     pos_y,
                                     np.clip(


### PR DESCRIPTION
# Handling cases where WSI doesn't start at x,y = 0

## ✨ Context

When trying to segment artifacts, LazySlide expects tissue polygon as tile key, otherwise uses the whole image as a single tissue.

## 🧠 Rationale behind the change

If the WSI has x,y origins = 0, this is handled correctly. IF slides violate that assumption (e.g. .mrxs slides) this will break the artifact detection.

## Type of changes

- [ ] 🐛 Bugfix (changes that fix a problem with the current behavior)

## 🛠 What does this PR implement

Fallback for treating the whole slide as a single tissue doesn't start at `0,0` (previously hardcoded), but now retrieves the correct coordinates for x and y (which will be `0,0` most of the times)