### PR TITLE
Fix TopologyException in tile_tissues by validating geometries #239

### DIFF
--- a/src/lazyslide/preprocess/_tiles.py
+++ b/src/lazyslide/preprocess/_tiles.py
@@ -143,6 +143,8 @@ def tile_tissues(
     for _, row in contours.iterrows():
         tissue_id = row["tissue_id"]
         cnt = row["geometry"]
+        if not cnt.is_valid:
+            cnt = cnt.buffer(0)
         minx, miny, maxx, maxy = cnt.bounds
         height, width = (maxy - miny, maxx - minx)
 


### PR DESCRIPTION
# Title
Fix TopologyException in `tile_tissues` by validating geometries (Closes #239)

## ✨ Context
This PR addresses a failure in `zs.pp.tile_tissues()` caused by invalid geometries in tissue contours. Specifically, certain slides produce a `shapely.errors.GEOSException: TopologyException` during the intersection operation.
The issue originates from invalid polygon geometries (`cnt`) retrieved from the contours GeoDataFrame, which causes GEOS to fail when computing intersections.

## 🧠 Rationale behind the change
The failure occurs because GEOS requires valid geometries for spatial operations like `intersection`. In some cases, the tissue contours contain self-intersections or topology inconsistencies.

To resolve this, a validation and repair step is introduced:
- Check if geometry is valid using `cnt.is_valid`
- Repair invalid geometries using `cnt.buffer(0)`

Pros: Prevents crashes and ensures robustness across diverse slide inputs.
Cons: `buffer(0)` introduces a small computational overhead, but this is minimal compared to the benefit of preventing runtime failures.This is a widely accepted approach in Shapely/GeoPandas workflows for fixing invalid geometries.

## Type of changes
- [x] 🐛 Bugfix (changes that fix a problem with the current behavior)

## 🛠 What does this PR implement
This PR introduces a geometry validation step in `src/lazyslide/preprocess/_tiles.py` to prevent GEOS topology errors.

Added validation and repair logic immediately after retrieving the geometry from the GeoDataFrame. Inserted after line ~145 (before geometry is used in downstream operations)
```python
cnt = row["geometry"]
if not cnt.is_valid:
    cnt = cnt.buffer(0)
```

## 🧪 How should this be tested?
1. Run `zs.pp.tile_tissues(wsi, tile_px=256, mpp=1.0)`
2. Observe `TopologyException` for affected slides

- `uv run pytest`