### PR TITLE
fix: `set_tissue_id` in plotting now accepts `tissue_key` parameter

### DIFF
--- a/src/lazyslide/plotting/_api.py
+++ b/src/lazyslide/plotting/_api.py
@@ -369,7 +369,7 @@ def tiles(
                     label_by="tissue_id" if show_id else None,
                 )
             if tid is not None:
-                viewer.set_tissue_id(tid)
+                viewer.set_tissue_id(tid, tissue_key=tissue_key)
             if mark_origin:
                 viewer.mark_origin()
             if scalebar:
@@ -555,7 +555,7 @@ def annotations(
         if scalebar:
             viewer.add_scalebar()
         if tissue_id is not None:
-            viewer.set_tissue_id(tid)
+            viewer.set_tissue_id(tid, tissue_key=tissue_key)
         if fill:
             viewer.add_polygons(
                 key,


### PR DESCRIPTION
# Title

## ✨ Context

Addressing what I described in #259

## 🧠 Rationale behind the change

Mirroring what's already done in the tissue plotting method for tiles and annotations.

## Type of changes

Which of these best describes the type of changes being introduced
(remove the unused options)

- [ ] ✨ New Feature (changes that introduce new functionality)
- [x] 🐛 Bugfix (changes that fix a problem with the current behavior)
- [ ] 💥 Breaking Change (Changes that radically modify current behavior and may be problematic)
- [ ] ⚗️ Experiments (A notebook with experimentation results)
- [ ] 📝 Documentation
- [ ] 🔥 Improvements (Minor refactoring, code changes or optimizations)
- [ ] ✅ Tests (Unit tests, integration tests, end-to-end tests)
- [ ] 👷 🔧 CI or Configuration Files
- [ ] Other (Please describe)