### PR TITLE
feat: deligate cell segmentation postprocess step to CPU workers

### DIFF
--- a/.github/workflows/build_lazyslide.yaml
+++ b/.github/workflows/build_lazyslide.yaml
@@ -71,7 +71,7 @@ jobs:
         with:
           # Only the hub cache (blobs/refs/snapshots) — never the token file.
           path: ${{ env.HF_HOME }}/hub
-          key: ${{ runner.os }}-hfdata-v2-${{ needs.resolve-dataset-sha.outputs.sha }}-${{ hashFiles('src/lazyslide/datasets/_sample.py', '.github/workflows/build_lazyslide.yaml') }}
+          key: ${{ runner.os }}-hfdata-v2-${{ needs.resolve-dataset-sha.outputs.sha }}-${{ hashFiles('src/lazyslide/datasets/_sample.py', 'scripts/prime_hf_cache.py', '.github/workflows/build_lazyslide.yaml') }}
           restore-keys: |
             ${{ runner.os }}-hfdata-v2-${{ needs.resolve-dataset-sha.outputs.sha }}-
             ${{ runner.os }}-hfdata-v2-
@@ -80,22 +80,7 @@ jobs:
         run: uv sync --dev
       - name: Download datasets and test models
         if: steps.cache.outputs.cache-hit != 'true' && env.HF_TOKEN != ''
-        run: |
-          uv run python - <<'PY'
-          import lazyslide as zs
-          from huggingface_hub import hf_hub_download
-          from lazyslide.tools._features import load_models
-
-          zs.datasets.sample()
-          zs.datasets.gtex_artery()
-          for repo_id in [
-              "timm/resnet50.a1_in1k",
-              "timm/test_resnet.r160_in1k",
-              "timm/test_vit.r160_in1k",
-          ]:
-              hf_hub_download(repo_id, "model.safetensors")
-          load_models("resnet50")
-          PY
+        run: uv run python scripts/prime_hf_cache.py
 
   test:
     needs: [resolve-dataset-sha, prime-datasets]
@@ -133,7 +118,7 @@ jobs:
         with:
           # Primed by prime-datasets; restore-only so the 12 test jobs never re-save.
           path: ${{ env.HF_HOME }}/hub
-          key: ${{ runner.os }}-hfdata-v2-${{ needs.resolve-dataset-sha.outputs.sha }}-${{ hashFiles('src/lazyslide/datasets/_sample.py', '.github/workflows/build_lazyslide.yaml') }}
+          key: ${{ runner.os }}-hfdata-v2-${{ needs.resolve-dataset-sha.outputs.sha }}-${{ hashFiles('src/lazyslide/datasets/_sample.py', 'scripts/prime_hf_cache.py', '.github/workflows/build_lazyslide.yaml') }}
           restore-keys: |
             ${{ runner.os }}-hfdata-v2-${{ needs.resolve-dataset-sha.outputs.sha }}-
             ${{ runner.os }}-hfdata-v2-

--- a/.github/workflows/build_lazyslide.yaml
+++ b/.github/workflows/build_lazyslide.yaml
@@ -44,8 +44,8 @@ jobs:
           echo "Resolved dataset SHA: $SHA"
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 
-  # Download the datasets ONCE per OS (3 jobs) before the test matrix, so the matrix
-  # test jobs never stampede HuggingFace on a cold cache. On a warm cache this is
+  # Download the HuggingFace assets ONCE per OS (3 jobs) before the test matrix,
+  # so the matrix test jobs never stampede HuggingFace on a cold cache. On a warm cache this is
   # a fast no-op gate (cache hit -> skip install + download).
   prime-datasets:
     needs: resolve-dataset-sha
@@ -65,23 +65,37 @@ jobs:
         with:
           python-version: '3.12'
           enable-cache: false
-      - name: Cache HuggingFace datasets
+      - name: Cache HuggingFace assets
         id: cache
         uses: actions/cache@v5
         with:
           # Only the hub cache (blobs/refs/snapshots) — never the token file.
           path: ${{ env.HF_HOME }}/hub
-          key: ${{ runner.os }}-hfdata-${{ needs.resolve-dataset-sha.outputs.sha }}-${{ hashFiles('src/lazyslide/datasets/_sample.py') }}
+          key: ${{ runner.os }}-hfdata-v2-${{ needs.resolve-dataset-sha.outputs.sha }}-${{ hashFiles('src/lazyslide/datasets/_sample.py', '.github/workflows/build_lazyslide.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-hfdata-${{ needs.resolve-dataset-sha.outputs.sha }}-
-            ${{ runner.os }}-hfdata-
+            ${{ runner.os }}-hfdata-v2-${{ needs.resolve-dataset-sha.outputs.sha }}-
+            ${{ runner.os }}-hfdata-v2-
       - name: Install project
         if: steps.cache.outputs.cache-hit != 'true' && env.HF_TOKEN != ''
         run: uv sync --dev
-      - name: Download datasets
+      - name: Download datasets and test models
         if: steps.cache.outputs.cache-hit != 'true' && env.HF_TOKEN != ''
         run: |
-          uv run python -c "import lazyslide as zs; zs.datasets.sample(); zs.datasets.gtex_artery();"
+          uv run python - <<'PY'
+          import lazyslide as zs
+          from huggingface_hub import hf_hub_download
+          from lazyslide.tools._features import load_models
+
+          zs.datasets.sample()
+          zs.datasets.gtex_artery()
+          for repo_id in [
+              "timm/resnet50.a1_in1k",
+              "timm/test_resnet.r160_in1k",
+              "timm/test_vit.r160_in1k",
+          ]:
+              hf_hub_download(repo_id, "model.safetensors")
+          load_models("resnet50")
+          PY
 
   test:
     needs: [resolve-dataset-sha, prime-datasets]
@@ -114,15 +128,15 @@ jobs:
           cache-dependency-glob: "uv.lock"
       - name: Install project
         run: uv sync --dev
-      - name: Restore HuggingFace datasets cache
+      - name: Restore HuggingFace assets cache
         uses: actions/cache/restore@v5
         with:
           # Primed by prime-datasets; restore-only so the 12 test jobs never re-save.
           path: ${{ env.HF_HOME }}/hub
-          key: ${{ runner.os }}-hfdata-${{ needs.resolve-dataset-sha.outputs.sha }}-${{ hashFiles('src/lazyslide/datasets/_sample.py') }}
+          key: ${{ runner.os }}-hfdata-v2-${{ needs.resolve-dataset-sha.outputs.sha }}-${{ hashFiles('src/lazyslide/datasets/_sample.py', '.github/workflows/build_lazyslide.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-hfdata-${{ needs.resolve-dataset-sha.outputs.sha }}-
-            ${{ runner.os }}-hfdata-
+            ${{ runner.os }}-hfdata-v2-${{ needs.resolve-dataset-sha.outputs.sha }}-
+            ${{ runner.os }}-hfdata-v2-
       - name: Tests
         run: |
           uv run pytest tests -n auto --cov=src/lazyslide --cov-report=xml --cov-report=html

--- a/.github/workflows/build_lazyslide.yaml
+++ b/.github/workflows/build_lazyslide.yaml
@@ -99,6 +99,9 @@ jobs:
       # keeps the token off disk (and out of the cache), and is empty-safe on forks.
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
       HF_HUB_DISABLE_SYMLINKS_WARNING: "1"  # quiet Windows copy-fallback noise
+      HF_HUB_OFFLINE: "1"
+      HF_DATASETS_OFFLINE: "1"
+      TRANSFORMERS_OFFLINE: "1"
       # Empty secret (fork PRs) -> '1' -> conftest skips dataset download/tests.
       LAZYSLIDE_SKIP_DATASET_TESTS: ${{ secrets.HF_TOKEN == '' && '1' || '0' }}
     steps:

--- a/scripts/prime_hf_cache.py
+++ b/scripts/prime_hf_cache.py
@@ -11,6 +11,13 @@ TIMM_TEST_MODEL_REPOS = (
     "timm/test_vit.r160_in1k",
 )
 
+HF_MODEL_FILES = (
+    (
+        "RendeiroLab/LazySlide-models-gpl",
+        "PathProfiler/PathProfiler_tissue_seg_exported.pt2",
+    ),
+)
+
 
 def main():
     zs.datasets.sample()
@@ -18,6 +25,9 @@ def main():
 
     for repo_id in TIMM_TEST_MODEL_REPOS:
         hf_hub_download(repo_id, "model.safetensors")
+
+    for repo_id, filename in HF_MODEL_FILES:
+        hf_hub_download(repo_id, filename)
 
     load_models("resnet50")
 

--- a/scripts/prime_hf_cache.py
+++ b/scripts/prime_hf_cache.py
@@ -1,0 +1,26 @@
+"""Prime Hugging Face cache entries needed by CI tests."""
+
+from huggingface_hub import hf_hub_download
+
+import lazyslide as zs
+from lazyslide.tools._features import load_models
+
+TIMM_TEST_MODEL_REPOS = (
+    "timm/resnet50.a1_in1k",
+    "timm/test_resnet.r160_in1k",
+    "timm/test_vit.r160_in1k",
+)
+
+
+def main():
+    zs.datasets.sample()
+    zs.datasets.gtex_artery()
+
+    for repo_id in TIMM_TEST_MODEL_REPOS:
+        hf_hub_download(repo_id, "model.safetensors")
+
+    load_models("resnet50")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lazyslide/cv/mask.py
+++ b/src/lazyslide/cv/mask.py
@@ -10,6 +10,8 @@ import numpy as np
 import pandas as pd
 from geopandas import GeoDataFrame
 from shapely import Polygon
+from shapely.affinity import translate
+from skimage.measure import regionprops
 
 from lazyslide._utils import find_stack_level
 
@@ -448,6 +450,7 @@ class InstanceMap(Mask):
         min_hole_area: float = 0,
         detect_holes: bool = True,
         ignore_index: int | Sequence[int] | None = None,
+        region_filter=None,
     ) -> gpd.GeoDataFrame:
         """
         Convert :term:`instance mask` to :term:`polygons <polygon>`.
@@ -471,24 +474,52 @@ class InstanceMap(Mask):
         """
         if ignore_index is not None:
             raise ValueError("ignore_index is not supported for InstanceMap.")
-        instance_ids = np.unique(self.mask)
-        instances = []
-        kept_ids = []
-        for instance_id in instance_ids:
-            if instance_id <= 0:  # Skip background
+        min_area_px = int(min_area * self.mask.size) if min_area < 1 else min_area
+        min_hole_area_px = (
+            int(min_hole_area * self.mask.size) if min_hole_area < 1 else min_hole_area
+        )
+        data = []
+        for region in regionprops(self.mask, cache=False):
+            instance_id = int(region.label)
+            if instance_id <= 0:
                 continue
-            instance_mask = np.asarray(self.mask == instance_id, dtype=np.uint8)
-            polys = binary_mask_to_polygons_with_prob(
-                instance_mask,
-                prob_map=self.prob_map,
-                min_area=min_area,
-                min_hole_area=min_hole_area,
+            if region_filter is not None and not region_filter(region):
+                continue
+            min_row, min_col, max_row, max_col = region.bbox
+            instance_crop = np.asarray(region.image, dtype=np.uint8)
+            polys = binary_mask_to_polygons(
+                instance_crop,
+                min_area=min_area_px,
+                min_hole_area=min_hole_area_px,
                 detect_holes=detect_holes,
+                contour_method=cv2.CHAIN_APPROX_SIMPLE,
             )
-            if len(polys) > 0:
-                instances.append(polys.iloc[0])
-                kept_ids.append(int(instance_id))
-        if len(instances) == 0:
+            if not polys:
+                continue
+
+            # Preserve the existing one-row-per-instance contract. In the rare
+            # case that a label has disconnected components, the first contour is
+            # selected just as ``polys.iloc[0]`` did in the previous path.
+            local_poly = polys[0]
+            row = {
+                "geometry": translate(local_poly, xoff=min_col, yoff=min_row),
+                "instance_id": instance_id,
+            }
+            if self.prob_map is not None:
+                if self.prob_map.ndim == 3:
+                    prob_crop = self.prob_map[:, min_row:max_row, min_col:max_col]
+                else:
+                    prob_crop = self.prob_map[min_row:max_row, min_col:max_col]
+                row.update(
+                    _polygon_probability_data(
+                        local_poly,
+                        instance_crop.shape,
+                        prob_crop,
+                        detect_holes=detect_holes,
+                    )
+                )
+            data.append(row)
+        if len(data) == 0:
             return gpd.GeoDataFrame()
         # Create a GeoDataFrame from the instances. ``instance_id`` is the source
         # integer label in the instance map: it lets callers map each polygon back
@@ -496,8 +527,7 @@ class InstanceMap(Mask):
         # guessing via centroid lookup. Reset the index first because each row was
         # taken with ``.iloc[0]`` (so they all share label 0); the column is then
         # assigned positionally.
-        instances = gpd.GeoDataFrame(instances).reset_index(drop=True)
-        instances["instance_id"] = kept_ids
+        instances = gpd.GeoDataFrame(data).reset_index(drop=True)
         if "class" in instances.columns:
             if self.class_names is not None:
                 instances["class"] = instances["class"].map(self.class_names)
@@ -603,6 +633,7 @@ def binary_mask_to_polygons(
     min_area: float = 0,
     min_hole_area: float = 0,
     detect_holes: bool = True,
+    contour_method: int = cv2.CHAIN_APPROX_NONE,
 ) -> Sequence[Polygon]:
     """
     Convert :term:`binary mask` to :term:`polygon`.
@@ -631,7 +662,7 @@ def binary_mask_to_polygons(
 
     mode = cv2.RETR_CCOMP if detect_holes else cv2.RETR_EXTERNAL
     contours, hierarchy = cv2.findContours(
-        binary_mask, mode=mode, method=cv2.CHAIN_APPROX_NONE
+        binary_mask, mode=mode, method=contour_method
     )
 
     if hierarchy is None:
@@ -686,6 +717,31 @@ def binary_mask_to_polygons(
             )
 
         return polys
+
+
+def _polygon_probability_data(
+    polygon: Polygon,
+    mask_shape: tuple[int, int],
+    prob_map: np.ndarray,
+    detect_holes: bool,
+) -> dict[str, float | int]:
+    """Calculate probability/class data inside a polygon-sized local crop."""
+    poly_mask = np.zeros(mask_shape, dtype=np.uint8)
+    points = np.asarray(polygon.exterior.coords, dtype=np.int32)
+    cv2.drawContours(poly_mask, [points], -1, 1, thickness=cv2.FILLED)
+    if detect_holes:
+        for hole in polygon.interiors:
+            hole_points = np.asarray(hole.coords, dtype=np.int32)
+            cv2.fillPoly(poly_mask, [hole_points], 0)
+
+    count = int(poly_mask.sum())
+    if count == 0:
+        return {"prob": 0.0}
+    if prob_map.ndim == 3:
+        class_probs = np.sum(prob_map * poly_mask, axis=(1, 2)) / count
+        class_id = int(np.argmax(class_probs))
+        return {"prob": float(class_probs[class_id]), "class": class_id}
+    return {"prob": float(np.sum(prob_map * poly_mask) / count)}
 
 
 def binary_mask_to_polygons_with_prob(

--- a/src/lazyslide/cv/mask.py
+++ b/src/lazyslide/cv/mask.py
@@ -468,8 +468,10 @@ class InstanceMap(Mask):
 
         Returns
         -------
-        Dict[int, Sequence[Polygon]]
-            Dictionary of :term:`polygons <polygon>` for each :term:`instance`.
+        geopandas.GeoDataFrame
+            One row per instance, with its polygon in ``geometry`` and source
+            label in ``instance_id``. Probability and class columns are included
+            when a probability map is available.
 
         """
         if ignore_index is not None:

--- a/src/lazyslide/cv/tiles_merger.py
+++ b/src/lazyslide/cv/tiles_merger.py
@@ -5,10 +5,6 @@ import numpy as np
 from shapely.ops import unary_union
 from shapely.strtree import STRtree
 
-# There are two ways to merge polygons:
-# 1. For semantic segmentation: Merge overlapping polygons using a spatial index (STRtree)
-# 2. For cell segmentation: Only preserve the largest polygon in each group of overlapping polygons.
-
 
 def iou(a, b):
     inter = a.intersection(b).area
@@ -19,7 +15,14 @@ def iou(a, b):
 def preprocess_gdf(gdf: gpd.GeoDataFrame, buffer_px: float = 0) -> gpd.GeoDataFrame:
     """Preprocess the :term:`polygons <polygon>` by applying a buffer and filtering invalid geometries."""
     new_gdf = gdf.copy()
-    new_gdf["geometry"] = gdf["geometry"].buffer(buffer_px)
+    if buffer_px != 0:
+        new_gdf["geometry"] = gdf["geometry"].buffer(buffer_px)
+    else:
+        invalid = ~new_gdf["geometry"].is_valid
+        if invalid.any():
+            geometry = new_gdf["geometry"].copy()
+            geometry.loc[invalid] = geometry.loc[invalid].buffer(0)
+            new_gdf["geometry"] = geometry
     # Filter out invalid and empty geometries efficiently
     return new_gdf[new_gdf["geometry"].is_valid & ~new_gdf["geometry"].is_empty]
 

--- a/src/lazyslide/datasets/_sample.py
+++ b/src/lazyslide/datasets/_sample.py
@@ -40,7 +40,11 @@ def _load_dataset(slide_file, zarr_file, with_data=True, pbar=False):
 
     # Avoid network calls in offline mode; CI primes the cache before tests.
     REPO_ID = "RendeiroLab/LazySlide-data"
-    if not _hf_offline():
+    if _hf_offline() and (
+        version.public != version.base_version or version.local is not None
+    ):
+        tag = None
+    elif not _hf_offline():
         api = HfApi()
         refs = api.list_repo_refs(REPO_ID, repo_type="dataset")
         tags = [t.name for t in refs.tags]

--- a/src/lazyslide/datasets/_sample.py
+++ b/src/lazyslide/datasets/_sample.py
@@ -1,3 +1,4 @@
+import os
 import warnings
 from pathlib import Path
 
@@ -5,6 +6,26 @@ from huggingface_hub import HfApi, hf_hub_download
 from wsidata import open_wsi
 
 from lazyslide._utils import find_stack_level
+
+_OFFLINE_ENV_VARS = ("HF_HUB_OFFLINE", "HF_DATASETS_OFFLINE", "TRANSFORMERS_OFFLINE")
+_TRUE_VALUES = {"1", "ON", "TRUE", "YES"}
+
+
+def _hf_offline() -> bool:
+    return any(
+        os.environ.get(name, "").strip().upper() in _TRUE_VALUES
+        for name in _OFFLINE_ENV_VARS
+    )
+
+
+def _download_dataset_file(repo_id: str, filename: str, revision: str | None) -> str:
+    return hf_hub_download(
+        repo_id,
+        filename,
+        repo_type="dataset",
+        revision=revision,
+        local_files_only=_hf_offline(),
+    )
 
 
 def _load_dataset(slide_file, zarr_file, with_data=True, pbar=False):
@@ -17,13 +38,14 @@ def _load_dataset(slide_file, zarr_file, with_data=True, pbar=False):
     # Get clean version
     tag = f"v{version.base_version}"
 
-    # Get all the tags from huggingface repo
+    # Avoid network calls in offline mode; CI primes the cache before tests.
     REPO_ID = "RendeiroLab/LazySlide-data"
-    api = HfApi()
-    refs = api.list_repo_refs(REPO_ID, repo_type="dataset")
-    tags = [t.name for t in refs.tags]
-    if tag not in tags:
-        tag = None
+    if not _hf_offline():
+        api = HfApi()
+        refs = api.list_repo_refs(REPO_ID, repo_type="dataset")
+        tags = [t.name for t in refs.tags]
+        if tag not in tags:
+            tag = None
 
     if pbar:
         warnings.warn(
@@ -32,12 +54,10 @@ def _load_dataset(slide_file, zarr_file, with_data=True, pbar=False):
             stacklevel=find_stack_level(),
         )
 
-    slide = hf_hub_download(REPO_ID, slide_file, repo_type="dataset", revision=tag)
+    slide = _download_dataset_file(REPO_ID, slide_file, revision=tag)
     slide_zarr = None
     if with_data:
-        slide_zarr_zip = hf_hub_download(
-            REPO_ID, zarr_file, repo_type="dataset", revision=tag
-        )
+        slide_zarr_zip = _download_dataset_file(REPO_ID, zarr_file, revision=tag)
         slide_zarr = Path(slide_zarr_zip.replace(".zip", ""))
         # Unzip the zarr file if it is a zip file
         # But only if it is not already unzipped

--- a/src/lazyslide/segmentation/_cell.py
+++ b/src/lazyslide/segmentation/_cell.py
@@ -66,6 +66,8 @@ def cells(
     pbar=True,
     extract_features: bool = False,
     low_memory: bool = False,
+    postprocess_workers: int = 0,
+    overlap_ownership: bool = False,
     key_added="cells",
     **model_kwargs,
 ):
@@ -119,6 +121,14 @@ def cells(
         When ``extract_features=True``, write intermediate feature chunks to
         on-disk mmap files and only materialize features that survive filtering
         and NMS.
+    postprocess_workers : int, default: 0
+        Number of CPU threads used to polygonize completed inference batches.
+        Set to 1 to overlap GPU inference with CPU postprocessing. In-flight
+        work is bounded to two batches per worker.
+    overlap_ownership : bool, default: False
+        For overlapping tiles, polygonize an instance only in the covering tile
+        whose center is nearest to its centroid. This removes most duplicate
+        polygonization while retaining NMS as a safety net.
     key_added : str, default: "cells"
         The key for the added cell shapes.
 
@@ -170,6 +180,8 @@ def cells(
         pbar=pbar,
         extract_features=extract_features,
         low_memory=low_memory,
+        postprocess_workers=postprocess_workers,
+        overlap_ownership=overlap_ownership,
     )
     result = runner.run()
     if extract_features:
@@ -248,6 +260,8 @@ def cell_types(
     pbar=True,
     extract_features: bool = False,
     low_memory: bool = False,
+    postprocess_workers: int = 0,
+    overlap_ownership: bool = False,
     key_added="cell_types",
     **model_kwargs,
 ):
@@ -300,6 +314,11 @@ def cell_types(
         When ``extract_features=True``, write intermediate feature chunks to
         on-disk mmap files and only materialize features that survive filtering
         and NMS.
+    postprocess_workers : int, default: 0
+        Number of CPU threads used to polygonize completed inference batches.
+    overlap_ownership : bool, default: False
+        For overlapping tiles, discard duplicate instances before polygonization
+        using nearest-tile-center ownership.
     key_added : str, default: "cell_types"
         The key for the added cell type shapes.
 
@@ -332,6 +351,8 @@ def cell_types(
         pbar=pbar,
         extract_features=extract_features,
         low_memory=low_memory,
+        postprocess_workers=postprocess_workers,
+        overlap_ownership=overlap_ownership,
         key_added=key_added,
         **model_kwargs,
     )

--- a/src/lazyslide/segmentation/_seg_runner.py
+++ b/src/lazyslide/segmentation/_seg_runner.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import tempfile
 import warnings
 from abc import ABC, abstractmethod
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import nullcontext
 from functools import cached_property
 from typing import TYPE_CHECKING, Callable, List, Literal, Mapping
@@ -10,7 +12,7 @@ from typing import TYPE_CHECKING, Callable, List, Literal, Mapping
 import geopandas as gpd
 import numpy as np
 import pandas as pd
-from shapely import box, prepare
+from shapely import STRtree, box, prepare
 from wsidata import TileSpec, WSIData
 from wsidata.io import add_shapes
 
@@ -739,6 +741,8 @@ class CellSegmentationRunner(Runner):
         pbar: bool = True,
         extract_features: bool = False,
         low_memory: bool = False,
+        postprocess_workers: int = 0,
+        overlap_ownership: bool = False,
     ):
         self.wsi = wsi
         self.model = model
@@ -756,9 +760,145 @@ class CellSegmentationRunner(Runner):
         self.pbar = pbar
         self.extract_features = extract_features
         self.low_memory = low_memory
+        if postprocess_workers < 0:
+            raise ValueError("postprocess_workers must be non-negative")
+        self.postprocess_workers = postprocess_workers
 
         self.tile_spec = wsi.tile_spec(tile_key)
         self.downsample = self.tile_spec.base_downsample
+        self.overlap_ownership = overlap_ownership and (
+            self.tile_spec.overlap_x > 0 or self.tile_spec.overlap_y > 0
+        )
+        self._tile_bounds = None
+        self._tile_centers = None
+        self._tile_neighbors = None
+        self._tile_position_indices = None
+        if self.overlap_ownership:
+            tiles = self.wsi[self.tile_key]
+            bounds = tiles.bounds[["minx", "miny", "maxx", "maxy"]].to_numpy()
+            self._tile_bounds = bounds
+            self._tile_centers = np.column_stack(
+                ((bounds[:, 0] + bounds[:, 2]) / 2, (bounds[:, 1] + bounds[:, 3]) / 2)
+            )
+            tree = STRtree(tiles.geometry.to_numpy())
+            self._tile_neighbors = [
+                np.asarray(tree.query(geom, predicate="intersects"), dtype=np.int64)
+                for geom in tiles.geometry
+            ]
+            self._tile_position_indices = {
+                (float(row[0]), float(row[1])): i for i, row in enumerate(bounds)
+            }
+
+    def _instance_owner_filter(self, pos_x: float, pos_y: float):
+        if not self.overlap_ownership:
+            return None
+        current = self._tile_position_indices.get((float(pos_x), float(pos_y)))
+        if current is None:
+            return None
+        neighbors = self._tile_neighbors[current]
+
+        def owns_region(region) -> bool:
+            row, col = region.centroid
+            point = np.asarray(
+                [
+                    float(pos_x) + col * self.downsample,
+                    float(pos_y) + row * self.downsample,
+                ]
+            )
+            bounds = self._tile_bounds[neighbors]
+            covered = (
+                (bounds[:, 0] <= point[0])
+                & (point[0] <= bounds[:, 2])
+                & (bounds[:, 1] <= point[1])
+                & (point[1] <= bounds[:, 3])
+            )
+            candidates = neighbors[covered]
+            if candidates.size == 0 or current not in candidates:
+                return True
+            delta = self._tile_centers[candidates] - point
+            distance = np.einsum("ij,ij->i", delta, delta)
+            owner = int(candidates[np.argmin(distance)])
+            return owner == current
+
+        return owns_region
+
+    def _postprocess_batch(
+        self,
+        instance_map: np.ndarray,
+        probability_map: np.ndarray | None,
+        patch_token_map: np.ndarray | None,
+        xs: np.ndarray,
+        ys: np.ndarray,
+        tile_box,
+        tissue,
+        class_names,
+    ) -> list[tuple[gpd.GeoDataFrame, np.ndarray | None]]:
+        """Polygonize and filter one inference batch on a CPU worker."""
+        batch_results = []
+        has_tokens = self.extract_features and patch_token_map is not None
+        for i in range(len(xs)):
+            pos_x = xs[i]
+            pos_y = ys[i]
+            out = instance_map[i]
+            prob_map = probability_map[i] if probability_map is not None else None
+
+            m = InstanceMap(out, prob_map=prob_map, class_names=class_names)
+            df = m.to_polygons(
+                detect_holes=False,
+                region_filter=self._instance_owner_filter(pos_x, pos_y),
+            )
+            if len(df) == 0:
+                continue
+
+            df = df[~df["geometry"].intersects(tile_box)]
+            if len(df) == 0:
+                continue
+
+            df = df.copy()
+            geometry = df["geometry"].affine_transform(
+                [self.downsample, 0, 0, self.downsample, pos_x, pos_y]
+            )
+            invalid = ~geometry.is_valid
+            if invalid.any():
+                geometry = geometry.copy()
+                geometry.loc[invalid] = geometry.loc[invalid].buffer(0)
+            df["geometry"] = geometry
+
+            if self.size_filter:
+                df = df[df["geometry"].area.between(*self.nucleus_size)]
+                if len(df) == 0:
+                    continue
+            df = df[df["geometry"].intersects(tissue)]
+            if len(df) == 0:
+                continue
+            if "class" in df.columns:
+                df = df[df["class"] != "Background"]
+                if len(df) == 0:
+                    continue
+
+            features = None
+            if has_tokens:
+                inst_arr = df["instance_id"].to_numpy()
+                pooled = _pool_cell_features(
+                    out, patch_token_map[i], np.unique(inst_arr)
+                )
+                features = np.stack([pooled[int(inst)] for inst in inst_arr])
+
+            batch_results.append(
+                (df.drop(columns="instance_id", errors="ignore"), features)
+            )
+        if not batch_results:
+            return []
+
+        # Collapse tile-sized frames while the batch is still on the CPU worker.
+        # The main thread then accumulates O(batches), rather than O(tiles),
+        # frames for the final concatenation.
+        frames, feature_chunks = zip(*batch_results)
+        batch_frame = gpd.GeoDataFrame(pd.concat(frames, ignore_index=True))
+        batch_features = None
+        if has_tokens:
+            batch_features = np.concatenate(feature_chunks, axis=0)
+        return [(batch_frame, batch_features)]
 
     def run(
         self,
@@ -787,10 +927,12 @@ class CellSegmentationRunner(Runner):
                     tile_key=self.tile_key, transform=self.transform
                 )
 
+                pin_memory = torch.device(self.device).type == "cuda"
                 tile_loader = DataLoader(
                     tile_dataset,
                     batch_size=self.batch_size,
                     num_workers=self.num_workers,
+                    pin_memory=pin_memory,
                 )
 
                 results = []
@@ -815,132 +957,104 @@ class CellSegmentationRunner(Runner):
                     "Processing tiles", total=len(tile_dataset)
                 )
 
-                for chunk in tile_loader:
-                    images = chunk["image"]
-                    xs, ys = np.asarray(chunk["x"]), np.asarray(chunk["y"])
-                    if self.device is not None:
-                        images = images.to(self.device)
-                    output = self.model.segment(images)
-
-                    instance_map = output.instance_map
-                    if instance_map is None:
-                        raise ValueError(
-                            "Cell segmentation requires instance_map "
-                            "but the model returned None. "
-                            "This model may only support semantic segmentation."
-                        )
-                    probability_map = output.probability_map
-                    patch_token_map = output.patch_token_map
-
-                    # Resolve class_names from output if not provided
-                    if self.class_names is None and output.classes is not None:
-                        self.class_names = {
-                            i: name for i, name in enumerate(output.classes)
-                        }
-
-                    # Get output and convert to numpy
-                    if isinstance(instance_map, torch.Tensor):
-                        instance_map = instance_map.detach().cpu().to(torch.int).numpy()
-                    if probability_map is not None:
-                        if isinstance(probability_map, torch.Tensor):
-                            probability_map = probability_map.detach().cpu().numpy()
-                    if patch_token_map is not None:
-                        if isinstance(patch_token_map, torch.Tensor):
-                            patch_token_map = (
-                                patch_token_map.detach().cpu().float().numpy()
-                            )
-
-                    has_tokens = self.extract_features and patch_token_map is not None
-                    if (
-                        self.extract_features
-                        and patch_token_map is None
-                        and not _warned_no_tokens
-                    ):
-                        warnings.warn(
-                            "extract_features=True but model does not return "
-                            "patch_token_map. Feature extraction will be skipped.",
-                            stacklevel=find_stack_level(),
-                        )
-                        _warned_no_tokens = True
-
-                    for i in range(len(xs)):
-                        pos_x = xs[i]
-                        pos_y = ys[i]
-                        out = instance_map[i]
-                        if probability_map is not None:
-                            prob_map = probability_map[i]
-                        else:
-                            prob_map = None
-
-                        # Convert the instance map to one polygon per instance.
-                        # ``df`` carries an ``instance_id`` column linking each row
-                        # back to its source instance in ``out``.
-                        m = InstanceMap(
-                            out,
-                            prob_map=prob_map,
-                            class_names=self.class_names,
-                        )
-                        df = m.to_polygons(detect_holes=False)
-                        if len(df) == 0:
-                            continue
-
-                        # Drop cells touching the tile edge (clipped instances).
-                        df = df[~df["geometry"].intersects(tile_box)]
-                        if len(df) == 0:
-                            continue
-
-                        # Move the polygons to the global coordinate
-                        df = df.copy()
-                        df["geometry"] = (
-                            df["geometry"]
-                            .scale(
-                                xfact=self.downsample,
-                                yfact=self.downsample,
-                                origin=(0, 0),
-                            )
-                            .translate(xoff=pos_x, yoff=pos_y)
-                            .buffer(0)
-                        )
-                        if self.size_filter:
-                            df = df[df["geometry"].area.between(*self.nucleus_size)]
-                            if len(df) == 0:
-                                continue
-                        df = df[df["geometry"].intersects(tissue)]
-                        if len(df) == 0:
-                            continue
-                        if "class" in df.columns:
-                            df = df[df["class"] != "Background"]
-                            if len(df) == 0:
-                                continue
-
-                        # Assign a globally-unique, stable cell_id to every cell.
+                def collect(batch_results):
+                    nonlocal global_cell_idx
+                    for df, features in batch_results:
                         n = len(df)
                         cell_ids = np.arange(
                             global_cell_idx, global_cell_idx + n, dtype=np.int64
                         )
                         global_cell_idx += n
+                        df = df.copy()
                         df["cell_id"] = cell_ids
+                        if features is not None:
+                            feature_store.append(features, cell_ids)
+                        results.append(df)
 
-                        # Bind per-cell features by instance_id — exact, no centroid
-                        # guessing. Tokens are pooled over each surviving instance's
-                        # full mask, then looked up by the row's instance_id. Every
-                        # row's instance_id produced this polygon, so a feature always
-                        # exists and no cell is silently dropped.
-                        if has_tokens:
-                            token_map_i = patch_token_map[i]  # [D, PH, PW]
-                            inst_arr = df["instance_id"].to_numpy()
-                            cell_features = _pool_cell_features(
-                                out, token_map_i, np.unique(inst_arr)
+                executor = (
+                    ThreadPoolExecutor(
+                        max_workers=self.postprocess_workers,
+                        thread_name_prefix="lazyslide-cell-postprocess",
+                    )
+                    if self.postprocess_workers
+                    else None
+                )
+                pending = deque()
+                max_pending = max(1, self.postprocess_workers * 2)
+                try:
+                    for chunk in tile_loader:
+                        images = chunk["image"]
+                        xs, ys = np.asarray(chunk["x"]), np.asarray(chunk["y"])
+                        if self.device is not None:
+                            images = images.to(
+                                self.device,
+                                non_blocking=pin_memory,
                             )
-                            feature_store.append(
-                                np.stack(
-                                    [cell_features[int(inst)] for inst in inst_arr]
-                                ),
-                                cell_ids,
+                        output = self.model.segment(images)
+
+                        instance_map = output.instance_map
+                        if instance_map is None:
+                            raise ValueError(
+                                "Cell segmentation requires instance_map "
+                                "but the model returned None. "
+                                "This model may only support semantic segmentation."
+                            )
+                        probability_map = output.probability_map
+                        patch_token_map = output.patch_token_map
+
+                        if self.class_names is None and output.classes is not None:
+                            self.class_names = {
+                                i: name for i, name in enumerate(output.classes)
+                            }
+
+                        if isinstance(instance_map, torch.Tensor):
+                            instance_map = (
+                                instance_map.detach().cpu().to(torch.int).numpy()
+                            )
+                        if isinstance(probability_map, torch.Tensor):
+                            probability_map = probability_map.detach().cpu().numpy()
+                        if isinstance(patch_token_map, torch.Tensor):
+                            patch_token_map = (
+                                patch_token_map.detach().cpu().float().numpy()
                             )
 
-                        results.append(df.drop(columns="instance_id", errors="ignore"))
-                    progress_bar.update(task, advance=len(images))
+                        if (
+                            self.extract_features
+                            and patch_token_map is None
+                            and not _warned_no_tokens
+                        ):
+                            warnings.warn(
+                                "extract_features=True but model does not return "
+                                "patch_token_map. Feature extraction will be skipped.",
+                                stacklevel=find_stack_level(),
+                            )
+                            _warned_no_tokens = True
+
+                        args = (
+                            instance_map,
+                            probability_map,
+                            patch_token_map,
+                            xs,
+                            ys,
+                            tile_box,
+                            tissue,
+                            self.class_names,
+                        )
+                        if executor is None:
+                            collect(self._postprocess_batch(*args))
+                        else:
+                            pending.append(
+                                executor.submit(self._postprocess_batch, *args)
+                            )
+                            if len(pending) >= max_pending:
+                                collect(pending.popleft().result())
+                        progress_bar.update(task, advance=len(images))
+
+                    while pending:
+                        collect(pending.popleft().result())
+                finally:
+                    if executor is not None:
+                        executor.shutdown(wait=True, cancel_futures=True)
             progress_bar.refresh()
         # If no results
         empty = gpd.GeoDataFrame(columns=["geometry", "cell_id"])

--- a/tests/test_huggingface_offline.py
+++ b/tests/test_huggingface_offline.py
@@ -1,7 +1,7 @@
 from lazyslide.datasets import _sample
 
 
-def test_load_dataset_does_not_query_refs_in_offline_mode(monkeypatch):
+def test_load_dataset_does_not_query_refs_for_release_in_offline_mode(monkeypatch):
     calls = []
 
     class FailApi:
@@ -27,10 +27,47 @@ def test_load_dataset_does_not_query_refs_in_offline_mode(monkeypatch):
     monkeypatch.setattr(_sample, "HfApi", FailApi)
     monkeypatch.setattr(_sample, "hf_hub_download", fake_download)
     monkeypatch.setattr(_sample, "open_wsi", fake_open_wsi)
+    monkeypatch.setattr("lazyslide.__version__", "0.3.0")
 
     wsi = _sample._load_dataset("sample.svs", "sample.zarr.zip", with_data=False)
 
     assert wsi == {"slide": "/tmp/sample.svs", "store": None}
     assert len(calls) == 1
     assert calls[0]["local_files_only"] is True
-    assert calls[0]["revision"].startswith("v")
+    assert calls[0]["revision"] == "v0.3.0"
+
+
+def test_load_dataset_uses_default_revision_for_dev_versions_offline(monkeypatch):
+    calls = []
+
+    class FailApi:
+        def __init__(self):
+            raise AssertionError("HfApi should not be used in offline mode")
+
+    def fake_download(repo_id, filename, repo_type, revision, local_files_only=False):
+        calls.append(
+            {
+                "repo_id": repo_id,
+                "filename": filename,
+                "repo_type": repo_type,
+                "revision": revision,
+                "local_files_only": local_files_only,
+            }
+        )
+        return f"/tmp/{filename}"
+
+    def fake_open_wsi(slide, store=None):
+        return {"slide": slide, "store": store}
+
+    monkeypatch.setenv("HF_DATASETS_OFFLINE", "1")
+    monkeypatch.setattr(_sample, "HfApi", FailApi)
+    monkeypatch.setattr(_sample, "hf_hub_download", fake_download)
+    monkeypatch.setattr(_sample, "open_wsi", fake_open_wsi)
+    monkeypatch.setattr("lazyslide.__version__", "0.3.0.post1")
+
+    wsi = _sample._load_dataset("sample.svs", "sample.zarr.zip", with_data=False)
+
+    assert wsi == {"slide": "/tmp/sample.svs", "store": None}
+    assert len(calls) == 1
+    assert calls[0]["local_files_only"] is True
+    assert calls[0]["revision"] is None

--- a/tests/test_huggingface_offline.py
+++ b/tests/test_huggingface_offline.py
@@ -1,0 +1,36 @@
+from lazyslide.datasets import _sample
+
+
+def test_load_dataset_does_not_query_refs_in_offline_mode(monkeypatch):
+    calls = []
+
+    class FailApi:
+        def __init__(self):
+            raise AssertionError("HfApi should not be used in offline mode")
+
+    def fake_download(repo_id, filename, repo_type, revision, local_files_only=False):
+        calls.append(
+            {
+                "repo_id": repo_id,
+                "filename": filename,
+                "repo_type": repo_type,
+                "revision": revision,
+                "local_files_only": local_files_only,
+            }
+        )
+        return f"/tmp/{filename}"
+
+    def fake_open_wsi(slide, store=None):
+        return {"slide": slide, "store": store}
+
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setattr(_sample, "HfApi", FailApi)
+    monkeypatch.setattr(_sample, "hf_hub_download", fake_download)
+    monkeypatch.setattr(_sample, "open_wsi", fake_open_wsi)
+
+    wsi = _sample._load_dataset("sample.svs", "sample.zarr.zip", with_data=False)
+
+    assert wsi == {"slide": "/tmp/sample.svs", "store": None}
+    assert len(calls) == 1
+    assert calls[0]["local_files_only"] is True
+    assert calls[0]["revision"].startswith("v")

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -93,6 +93,28 @@ class TestCellSegmentation:
         model = MockCellSegmentationModel()
         zs.seg.cells(wsi, model, tile_key="cell_tiles", key_added="cells")
 
+    def test_cell_postprocess_worker_matches_inline(self, wsi):
+        zs.pp.tile_tissues(wsi, tile_px=512, mpp=0.5, key_added="worker_tiles")
+        zs.seg.cells(
+            wsi,
+            MockCellSegmentationModel(),
+            tile_key="worker_tiles",
+            key_added="cells_inline",
+        )
+        zs.seg.cells(
+            wsi,
+            MockCellSegmentationModel(),
+            tile_key="worker_tiles",
+            key_added="cells_worker",
+            postprocess_workers=1,
+        )
+
+        inline = wsi.shapes["cells_inline"].reset_index(drop=True)
+        worker = wsi.shapes["cells_worker"].reset_index(drop=True)
+        assert list(inline.columns) == list(worker.columns)
+        assert inline.drop(columns="geometry").equals(worker.drop(columns="geometry"))
+        assert inline.geometry.geom_equals_exact(worker.geometry, tolerance=0).all()
+
     def test_cell_classification(self, wsi):
         zs.pp.tile_tissues(wsi, tile_px=512, mpp=0.5, key_added="cell_tiles")
 


### PR DESCRIPTION
## ✨ Context

The postprocess time for cell segmentation may take too long when running on a big slide with a large number of cells. Serveral optimizations have been made and the work has been deligated to a CPU worker to run in parallel with GPU inference.

Closes #262 

## Type of changes

- [x] 🔥 Improvements (Minor refactoring, code changes or optimizations)
