### PR TITLE
ci: use huggingface commit SHA for datasets instead of version tag. V…

### DIFF
--- a/.github/workflows/build_lazyslide.yaml
+++ b/.github/workflows/build_lazyslide.yaml
@@ -118,6 +118,7 @@ jobs:
       - name: Install project
         run: uv sync --dev
       - name: Restore HuggingFace assets cache
+        if: env.LAZYSLIDE_SKIP_DATASET_TESTS != '1'
         uses: actions/cache/restore@v5
         with:
           # Primed by prime-datasets; restore-only so the 12 test jobs never re-save.

--- a/.github/workflows/build_lazyslide.yaml
+++ b/.github/workflows/build_lazyslide.yaml
@@ -58,6 +58,8 @@ jobs:
       HF_HOME: ${{ github.workspace }}/.hf_home
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
       HF_HUB_DISABLE_SYMLINKS_WARNING: "1"
+      # Prime the exact immutable revision consumed by the offline test jobs.
+      LAZYSLIDE_DATASET_REVISION: ${{ needs.resolve-dataset-sha.outputs.sha }}
     steps:
       - uses: actions/checkout@v6
       - name: Set up uv
@@ -101,6 +103,8 @@ jobs:
       HF_HUB_OFFLINE: "1"
       HF_DATASETS_OFFLINE: "1"
       TRANSFORMERS_OFFLINE: "1"
+      # Avoid package-version tags during CI. Release tags are created only after tests pass.
+      LAZYSLIDE_DATASET_REVISION: ${{ needs.resolve-dataset-sha.outputs.sha }}
       # Empty secret (fork PRs) -> '1' -> conftest skips dataset download/tests.
       LAZYSLIDE_SKIP_DATASET_TESTS: ${{ secrets.HF_TOKEN == '' && '1' || '0' }}
     steps:
@@ -119,9 +123,11 @@ jobs:
           # Primed by prime-datasets; restore-only so the 12 test jobs never re-save.
           path: ${{ env.HF_HOME }}/hub
           key: ${{ runner.os }}-hfdata-v2-${{ needs.resolve-dataset-sha.outputs.sha }}-${{ hashFiles('src/lazyslide/datasets/_sample.py', 'scripts/prime_hf_cache.py', '.github/workflows/build_lazyslide.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-hfdata-v2-${{ needs.resolve-dataset-sha.outputs.sha }}-
-            ${{ runner.os }}-hfdata-v2-
+          # prime-datasets must have saved this exact cache before the matrix starts.
+          fail-on-cache-miss: true
+      - name: Verify HuggingFace assets are available offline
+        if: env.LAZYSLIDE_SKIP_DATASET_TESTS != '1'
+        run: uv run python scripts/prime_hf_cache.py
       - name: Tests
         run: |
           uv run pytest tests -n auto --cov=src/lazyslide --cov-report=xml --cov-report=html
@@ -153,7 +159,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [resolve-dataset-sha, test]
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     permissions:
       id-token: write
@@ -176,8 +182,13 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           VERSION=${{ github.ref_name }}
+          DATASET_SHA=${{ needs.resolve-dataset-sha.outputs.sha }}
           echo "Detected version: $VERSION"
-          uv run scripts/tag_datasets.py create RendeiroLab/LazySlide-data "$VERSION"
+          if [ "$DATASET_SHA" = "none" ]; then
+            echo "Could not resolve the dataset revision for this release"
+            exit 1
+          fi
+          uv run scripts/tag_datasets.py create RendeiroLab/LazySlide-data "$VERSION" "$DATASET_SHA"
       - name: Tag LazySlide-tutorials
         env:
           GH_TOKEN: ${{ secrets.TUTORIAL_RELEASE_TOKEN }}

--- a/src/lazyslide/datasets/_sample.py
+++ b/src/lazyslide/datasets/_sample.py
@@ -9,6 +9,7 @@ from lazyslide._utils import find_stack_level
 
 _OFFLINE_ENV_VARS = ("HF_HUB_OFFLINE", "HF_DATASETS_OFFLINE", "TRANSFORMERS_OFFLINE")
 _TRUE_VALUES = {"1", "ON", "TRUE", "YES"}
+_DATASET_REVISION_ENV = "LAZYSLIDE_DATASET_REVISION"
 
 
 def _hf_offline() -> bool:
@@ -28,28 +29,33 @@ def _download_dataset_file(repo_id: str, filename: str, revision: str | None) ->
     )
 
 
-def _load_dataset(slide_file, zarr_file, with_data=True, pbar=False):
-    # Get the current version
+def _dataset_revision(repo_id: str) -> str | None:
+    """Resolve the dataset revision, honoring an explicit immutable CI pin."""
+    revision = os.environ.get(_DATASET_REVISION_ENV, "").strip()
+    if revision:
+        return revision
+
     from packaging.version import Version
 
     from lazyslide import __version__
 
     version = Version(__version__)
-    # Get clean version
-    tag = f"v{version.base_version}"
+    revision = f"v{version.base_version}"
 
-    # Avoid network calls in offline mode; CI primes the cache before tests.
+    if _hf_offline():
+        if version.public != version.base_version or version.local is not None:
+            return None
+        return revision
+
+    api = HfApi()
+    refs = api.list_repo_refs(repo_id, repo_type="dataset")
+    tags = [tag.name for tag in refs.tags]
+    return revision if revision in tags else None
+
+
+def _load_dataset(slide_file, zarr_file, with_data=True, pbar=False):
     REPO_ID = "RendeiroLab/LazySlide-data"
-    if _hf_offline() and (
-        version.public != version.base_version or version.local is not None
-    ):
-        tag = None
-    elif not _hf_offline():
-        api = HfApi()
-        refs = api.list_repo_refs(REPO_ID, repo_type="dataset")
-        tags = [t.name for t in refs.tags]
-        if tag not in tags:
-            tag = None
+    revision = _dataset_revision(REPO_ID)
 
     if pbar:
         warnings.warn(
@@ -58,10 +64,10 @@ def _load_dataset(slide_file, zarr_file, with_data=True, pbar=False):
             stacklevel=find_stack_level(),
         )
 
-    slide = _download_dataset_file(REPO_ID, slide_file, revision=tag)
+    slide = _download_dataset_file(REPO_ID, slide_file, revision=revision)
     slide_zarr = None
     if with_data:
-        slide_zarr_zip = _download_dataset_file(REPO_ID, zarr_file, revision=tag)
+        slide_zarr_zip = _download_dataset_file(REPO_ID, zarr_file, revision=revision)
         slide_zarr = Path(slide_zarr_zip.replace(".zip", ""))
         # Unzip the zarr file if it is a zip file
         # But only if it is not already unzipped

--- a/tests/test_huggingface_offline.py
+++ b/tests/test_huggingface_offline.py
@@ -23,6 +23,7 @@ def test_load_dataset_does_not_query_refs_for_release_in_offline_mode(monkeypatc
     def fake_open_wsi(slide, store=None):
         return {"slide": slide, "store": store}
 
+    monkeypatch.delenv("LAZYSLIDE_DATASET_REVISION", raising=False)
     monkeypatch.setenv("HF_HUB_OFFLINE", "1")
     monkeypatch.setattr(_sample, "HfApi", FailApi)
     monkeypatch.setattr(_sample, "hf_hub_download", fake_download)
@@ -59,6 +60,7 @@ def test_load_dataset_uses_default_revision_for_dev_versions_offline(monkeypatch
     def fake_open_wsi(slide, store=None):
         return {"slide": slide, "store": store}
 
+    monkeypatch.delenv("LAZYSLIDE_DATASET_REVISION", raising=False)
     monkeypatch.setenv("HF_DATASETS_OFFLINE", "1")
     monkeypatch.setattr(_sample, "HfApi", FailApi)
     monkeypatch.setattr(_sample, "hf_hub_download", fake_download)
@@ -71,3 +73,41 @@ def test_load_dataset_uses_default_revision_for_dev_versions_offline(monkeypatch
     assert len(calls) == 1
     assert calls[0]["local_files_only"] is True
     assert calls[0]["revision"] is None
+
+
+def test_explicit_dataset_revision_bypasses_version_tag_lookup(monkeypatch):
+    calls = []
+
+    class FailApi:
+        def __init__(self):
+            raise AssertionError("HfApi should not be used with an explicit revision")
+
+    def fake_download(repo_id, filename, repo_type, revision, local_files_only=False):
+        calls.append(
+            {
+                "repo_id": repo_id,
+                "filename": filename,
+                "repo_type": repo_type,
+                "revision": revision,
+                "local_files_only": local_files_only,
+            }
+        )
+        return f"/tmp/{filename}"
+
+    def fake_open_wsi(slide, store=None):
+        return {"slide": slide, "store": store}
+
+    dataset_sha = "d469afd4a763ad366861e8c49d4cf424bfad902c"
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("LAZYSLIDE_DATASET_REVISION", dataset_sha)
+    monkeypatch.setattr(_sample, "HfApi", FailApi)
+    monkeypatch.setattr(_sample, "hf_hub_download", fake_download)
+    monkeypatch.setattr(_sample, "open_wsi", fake_open_wsi)
+    monkeypatch.setattr("lazyslide.__version__", "0.12.0")
+
+    wsi = _sample._load_dataset("sample.svs", "sample.zarr.zip", with_data=False)
+
+    assert wsi == {"slide": "/tmp/sample.svs", "store": None}
+    assert len(calls) == 1
+    assert calls[0]["local_files_only"] is True
+    assert calls[0]["revision"] == dataset_sha


### PR DESCRIPTION
The version tag does not exist before the release happens, which will create a cycle dependency.

- [x] 👷 🔧 CI or Configuration Files